### PR TITLE
Fix documentation and test for OctoPrint chart

### DIFF
--- a/templates/NOTES.txt
+++ b/templates/NOTES.txt
@@ -17,5 +17,5 @@
 {{- else if contains "ClusterIP" .Values.service.type }}
   export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "octoprint.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
   echo "Visit http://127.0.0.1:8080 to use your application"
-  kubectl port-forward $POD_NAME 8080:80
+  kubectl port-forward $POD_NAME 8080:5000
 {{- end }}

--- a/templates/tests/test-connection.yaml
+++ b/templates/tests/test-connection.yaml
@@ -11,5 +11,5 @@ spec:
     - name: wget
       image: busybox
       command: ['wget']
-      args:  ['{{ include "octoprint.fullname" . }}:{{ .Values.service.port }}']
+      args:  ['--spider', '-q', 'http://{{ include "octoprint.fullname" . }}:{{ .Values.service.port }}']
   restartPolicy: Never

--- a/values.yaml
+++ b/values.yaml
@@ -24,7 +24,7 @@ podSecurityContext: {}
   # fsGroup: 2000
 
 securityContext:
-  # uses privileged to accses the raw device
+  # uses privileged to access the raw device
   # not sure which caps are needed otherwise
   privileged: true
   # capabilities:


### PR DESCRIPTION
## Summary
- correct a typo in the chart values file
- ensure test connection wget uses HTTP scheme
- clarify port‑forward example to match the service
- fail the Helm test on HTTP errors by adding `--spider -q`

## Testing
- `helm lint .` *(fails: `helm: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6841552157208320b51ae5690dcdca1c