### PR TITLE
Add config checksum helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ OctoPrint is the snappy web interface for your 3D printer that allows you to con
 | persistence.existingClaim | string | `nil` |  |
 | persistence.size | string | `"1Gi"` |  |
 | persistence.storageClassName | string | `nil` |  |
+| podAnnotations | object | `{}` |  |
 | podSecurityContext | object | `{}` |  |
 | readinessProbe.enabled | bool | `true` |  |
 | readinessProbe.failureThreshold | int | `3` |  |

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -149,3 +149,18 @@ Usage:
     {{- $value }}
 {{- end }}
 {{- end -}}
+
+{{/*
+Return a checksum of the configuration overlay so that deployments
+are rolled when the configuration changes.
+*/}}
+{{- define "octoprint.configChecksum" -}}
+{{- printf "%s" (toString .Values.config.overlay) | sha256sum -}}
+{{- end -}}
+
+{{/*
+Return the appropriate apiVersion for ingress resources.
+*/}}
+{{- define "octoprit.capabilities.ingress.apiVersion" -}}
+{{- print "networking.k8s.io/v1" -}}
+{{- end -}}

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -18,6 +18,11 @@ spec:
       labels:
         app.kubernetes.io/name: {{ include "octoprint.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
+      annotations:
+        checksum/config: {{ include "octoprint.configChecksum" . }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
     {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "octoprint.fullname" . -}}
-apiVersion: {{ include "common.capabilities.ingress.apiVersion" . }}
+apiVersion: {{ include "octoprit.capabilities.ingress.apiVersion" . }}
 kind: Ingress
 metadata:
   name: {{ $fullName }}

--- a/values.yaml
+++ b/values.yaml
@@ -13,6 +13,8 @@ imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
+podAnnotations: {}
+
 serviceAccount:
   # Specifies whether a service account should be created
   create: true


### PR DESCRIPTION
## Summary
- implement `octoprint.configChecksum` Helm macro
- add pod annotation support and checksum annotation in Deployment
- document new `podAnnotations` field in README
- implement `octoprit.capabilities.ingress.apiVersion` macro and use it in the Ingress template

## Testing
- `helm lint .`


------
https://chatgpt.com/codex/tasks/task_e_68416319117083208c5e8d485a7ad8f6

## Summary by Sourcery

Introduce config checksum and annotation enhancements, plus ingress apiVersion support to ensure pods and resources update correctly when configurations change.

New Features:
- Add a Helm macro to compute a SHA256 checksum of the configuration overlay
- Enable custom pod annotations and include checksum/config annotation in Deployment
- Introduce a Helm macro for the appropriate Ingress apiVersion and apply it in the Ingress template

Documentation:
- Document the new podAnnotations field in README