### PR TITLE
Fix Helm test URL argument

### DIFF
--- a/templates/tests/test-connection.yaml
+++ b/templates/tests/test-connection.yaml
@@ -10,6 +10,6 @@ spec:
   containers:
     - name: wget
       image: busybox
-      command: ['wget']
-      args:  ['--spider', '-q', 'http://{{ include "octoprint.fullname" . }}:{{ .Values.service.port }}']
+      command: ['wget', '-qO-']
+      args:  ['http://{{ include "octoprint.fullname" . }}:{{ .Values.service.port }}']
   restartPolicy: Never


### PR DESCRIPTION
## Summary
- simplify the connection test pod
- suppress wget output in test hook

## Testing
- `helm lint .`
- `helm template test-release .`

------
https://chatgpt.com/codex/tasks/task_e_684162ecacd88320a8d9dfa1a22533c6

## Summary by Sourcery

Tests:
- Replace wget spider check with `wget -qO-` and pass the full service URL in test-connection.yaml