### PR TITLE
Fix helm release packaging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,8 +21,10 @@ jobs:
 
       - name: Install helm-docs
         run: |
-          curl -L https://github.com/norwoodj/helm-docs/releases/download/v1.13.1/helm-docs_1.13.1_Linux_x86_64.tar.gz | tar -xz
-          install helm-docs /usr/local/bin/helm-docs
+          mkdir -p /tmp/helm-docs
+          curl -L https://github.com/norwoodj/helm-docs/releases/download/v1.13.1/helm-docs_1.13.1_Linux_x86_64.tar.gz | tar -xz -C /tmp/helm-docs
+          install /tmp/helm-docs/helm-docs /usr/local/bin/helm-docs
+          rm -rf /tmp/helm-docs
 
       - name: Lint chart
         run: helm lint .

--- a/.helmignore
+++ b/.helmignore
@@ -20,3 +20,4 @@
 .idea/
 *.tmproj
 .vscode/
+helm-docs


### PR DESCRIPTION
## Summary
- avoid packaging the helm-docs binary in the chart
- ignore `helm-docs` via `.helmignore`

## Testing
- `helm lint .`
- `helm template test-release .`

------
https://chatgpt.com/codex/tasks/task_e_686ec824068883209cff47101bf2622a

## Summary by Sourcery

Exclude the helm-docs binary from Helm chart packages and streamline its installation in the release workflow

Enhancements:
- Ignore helm-docs binary via .helmignore to prevent it from being packaged in the chart

CI:
- Install helm-docs in a temporary directory and clean up artifacts in the release workflow