### PR TITLE
Fix helm release packaging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,8 +21,10 @@ jobs:
 
       - name: Install helm-docs
         run: |
-          curl -L https://github.com/norwoodj/helm-docs/releases/download/v1.13.1/helm-docs_1.13.1_Linux_x86_64.tar.gz | tar -xz
-          install helm-docs /usr/local/bin/helm-docs
+          mkdir -p /tmp/helm-docs
+          curl -L https://github.com/norwoodj/helm-docs/releases/download/v1.13.1/helm-docs_1.13.1_Linux_x86_64.tar.gz | tar -xz -C /tmp/helm-docs
+          install /tmp/helm-docs/helm-docs /usr/local/bin/helm-docs
+          rm -rf /tmp/helm-docs
 
       - name: Lint chart
         run: helm lint .

--- a/.helmignore
+++ b/.helmignore
@@ -20,3 +20,4 @@
 .idea/
 *.tmproj
 .vscode/
+helm-docs


### PR DESCRIPTION
## Summary
- avoid packaging the helm-docs binary in the chart
- ignore `helm-docs` via `.helmignore`

## Testing
- `helm lint .`
- `helm template test-release .`

------
https://chatgpt.com/codex/tasks/task_e_686ec824068883209cff47101bf2622a

## Summary by Sourcery

Prevent the helm-docs binary from being included in Helm chart packages and streamline its installation in the CI release workflow.

Bug Fixes:
- Prevent the helm-docs binary from being included in packaged charts

Enhancements:
- Add `helm-docs` to `.helmignore` to exclude it from the chart

CI:
- Extract helm-docs to a temporary directory for installation and remove it after installing in the release workflow