### PR TITLE
Don't package the logo in the chart

### DIFF
--- a/.helmignore
+++ b/.helmignore
@@ -21,3 +21,4 @@
 *.tmproj
 .vscode/
 helm-docs
+logo.png


### PR DESCRIPTION
Add `logo.png` to `.helmignore` so it does not get packaged in the chart. Adding this huge logo to the chart means the chart is >1MB and therefore cannot be stored in a Kubernetes secret, which running `helm install` needs to do.

Chart size before this change:

```
jonathan@poseidon:~/git/octoprint-chart$ helm package .
Successfully packaged chart and saved it to: /home/jonathan/git/octoprint-chart/octoprint-0.3.5.tgz
jonathan@poseidon:~/git/octoprint-chart$ ls -lah octoprint-0.3.5.tgz
-rw-r--r--. 1 jonathan jonathan 1.4M Oct  6 12:19 /home/jonathan/git/octoprint-chart/octoprint-0.3.5.tgz
```

Chart size after this change:

```
jonathan@poseidon:~/git/octoprint-chart$ rm octoprint-0.3.5.tgz 
jonathan@poseidon:~/git/octoprint-chart$ helm package .
Successfully packaged chart and saved it to: /home/jonathan/git/octoprint-chart/octoprint-0.3.5.tgz
jonathan@poseidon:~/git/octoprint-chart$ ls -la octoprint-0.3.5.tgz
-rw-r--r--. 1 jonathan jonathan 10035 Oct  6 12:20 /home/jonathan/git/octoprint-chart/octoprint-0.3.5.tgz
```
10KB is an improvement on 1.4MB :D

Fixes #11

## Summary by Sourcery

Enhancements:
- Add logo.png to .helmignore to prevent bundling the large logo image in the chart