### PR TITLE
Add support for pod priority class

### DIFF
--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -31,6 +31,9 @@ spec:
       serviceAccountName: {{ template "octoprint.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           securityContext:

--- a/values.yaml
+++ b/values.yaml
@@ -36,6 +36,9 @@ securityContext:
   # runAsNonRoot: true
   # runAsUser: 1000
 
+# Set the pod priority class
+priorityClassName:
+
 service:
   type: ClusterIP
   port: 5000


### PR DESCRIPTION
This PR adds support for setting a Priority Class on the deployment, which can be used to prevent the octoprint pod from being pre-empted if the node is busy.

## Summary by Sourcery

New Features:
- Allow specifying a pod priority class via values to prevent preemption