### PR TITLE
Make the values schema match what is in the ingress template

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -42,14 +42,24 @@ service:
 
 ingress:
   enabled: false
+  ingressClassName:
   annotations: {}
+    # cert-manager.io/cluster-issuer: "letsencrypt-prod"
+    # May be required to upload large files
+    # nginx.ingress.kubernetes.io/proxy-body-size: "0"
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
-  hosts:
-    - host: chart-example.local
-      paths: []
+  hostname: chart-example.local
+  extraPaths: []
+    # - path: /example
+    #   pathType: ImplementationSpecific
+    #   backend: serviceName
+  extraHosts: []
+    # - host: chart-example.local
+    #   paths: []
 
-  tls: []
+  tls: false
+  extraTls: ""
   #  - secretName: chart-example-tls
   #    hosts:
   #      - chart-example.local


### PR DESCRIPTION
I noticed that the values provided in `values.yaml` did not match the actual `ingress.yaml` template, so I have fixed that. The template and the syntax is unchanged - this just makes the examples correct and easier to follow.

## Summary by Sourcery

Enhancements:
- Restructure the ingress section by renaming hosts to hostname, replacing tls array with boolean, and adding extraPaths, extraHosts, ingressClassName, and extraTls fields