### PR TITLE
Standardise printer device name

### DIFF
--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -101,8 +101,8 @@ spec:
               mountPath: /octoprint/octoprint
             - name: plugins
               mountPath: /octoprint/plugins
-            - name: ttyacm0
-              mountPath: /dev/ttyACM0
+            - name: printer
+              mountPath: {{ .Values.device }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -140,6 +140,6 @@ spec:
           {{- else }}
           emptyDir: {}
           {{- end }}
-        - name: ttyacm0
+        - name: printer
           hostPath:
             path: {{ .Values.device | quote }}


### PR DESCRIPTION
This PR ensures the device name on the system is the same as the device name inside the container. It also uses a generic name of `printer` on the volume, to avoid confusion.

My printer is `/dev/ttyUSB0` and it was confusing to see it mapped to `/dev/ttyACM0` inside the container.

## Summary by Sourcery

Standardise the printer device mapping by using a generic 'printer' volume name and parameterising the device path to ensure the host and container see the same device name.

Enhancements:
- Rename the volume name from 'ttyacm0' to 'printer' for consistency
- Use the .Values.device parameter for both mountPath and hostPath to align the host and container device names