### PR TITLE
Support for Init Containers, extraVolumes and extraVolumMounts

### DIFF
--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -31,6 +31,12 @@ spec:
       serviceAccountName: {{ template "octoprint.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- if .Values.initContainers }}
+      initContainers:
+      {{- with .Values.initContainers }}
+        {{- toYaml . | nindent 6 }}
+      {{- end }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           securityContext:
@@ -103,6 +109,9 @@ spec:
               mountPath: /octoprint/plugins
             - name: ttyacm0
               mountPath: /dev/ttyACM0
+            {{- with .Values.extraVolumeMounts}}
+              {{- toYaml . | nindent 12 }}
+            {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -143,3 +152,6 @@ spec:
         - name: ttyacm0
           hostPath:
             path: {{ .Values.device | quote }}
+        {{- with .Values.extraVolumes }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -34,7 +34,7 @@ spec:
       {{- if .Values.initContainers }}
       initContainers:
       {{- with .Values.initContainers }}
-        {{- toYaml . | nindent 6 }}
+        {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- end }}
       containers:

--- a/values.yaml
+++ b/values.yaml
@@ -36,9 +36,8 @@ securityContext:
   # runAsNonRoot: true
   # runAsUser: 1000
 
-initContainers: {}
-  # Specify initContainers as dictionary items. Each initContainer should have its own key.
-  # which also defines the order of execution
+initContainers: []
+  # Specify initContainers as list, which also defines the execution order
 
 service:
   type: ClusterIP

--- a/values.yaml
+++ b/values.yaml
@@ -36,6 +36,10 @@ securityContext:
   # runAsNonRoot: true
   # runAsUser: 1000
 
+initContainers: {}
+  # Specify initContainers as dictionary items. Each initContainer should have its own key.
+  # which also defines the order of execution
+
 service:
   type: ClusterIP
   port: 5000


### PR DESCRIPTION
Adding initContainers, extraVolumeMounts, extraVolumes to deployment, which is necessary when you want to modify config files using an initContainer.

## Summary by Sourcery

Add configurability for additional containers and volumes in the Helm deployment.

New Features:
- Allow specifying init containers via values.yaml and render them into the deployment spec.
- Support extra volume mounts on the main container configured through values.yaml.
- Support extra volumes on the pod configured through values.yaml.

Documentation:
- Document the new initContainers configuration option in values.yaml comments.